### PR TITLE
Contribution: Fix basic instalation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 1. Clone the repository:
 
 ```bash
-git clone git@github.com:pheralb/superui.git
+git clone https://github.com/pheralb/superui.git
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
Buenos días, he estado viendo el proyecto y he de reconocer que me ha gustado y por ello quiero contribuir y ser parte de él, arreglando almenos el código.

En esta PR corrijo el link de instalación básico.

Esto es lo que pone en las instrucciones:

`git clone git@github.com:pheralb/superui.git`

y es mas que obio que desde Bash te pida la key.
```

$ git clone git@github.com:pheralb/superui.git
Cloning into 'superui'...
The authenticity of host 'github.com (140.82.121.3)' can't be established.
ED***19 key fingerprint is SHA256:+**************zLDA****************.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com' (ED***19) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

El problema es que sino corregimos esto, habrá mucha gente que estará peridiendo la oporunidad de probarlo y por lo tanto ni forkear ni favoritos.

Solución que se propone:

`git clone https://github.com/pheralb/superui.git`

Es de esta forma bajo el protocolo https, y el link, se clona sin ningún problema, este maravilloso proyecto.

```
$ git clone https://github.com/pheralb/superui.git
Cloning into 'superui'...
remote: Enumerating objects: 2357, done.
remote: Counting objects: 100% (401/401), done.
remote: Compressing objects: 100% (203/203), done.
remote: Total 2357 (delta 280), reused 243 (delta 195), pack-reused 1956
Receiving objects: 100% (2357/2357), 1.14 MiB | 9.13 MiB/s, done.
Resolving deltas: 100% (1388/1388), done.
```
Os dejo el log file, para que así pues tengáis estadísticas de mejora de rapidez en un futuro, W11, MSI GE67 con Andorra conexion remota a PC de Barcelona, Download Mbps 923.58 Upload Mbps 858.56.

Buenas noches.
Miguel