### PR TITLE
Fix Docs page responsive on mobile

### DIFF
--- a/app/src/pages/docs/index.tsx
+++ b/app/src/pages/docs/index.tsx
@@ -16,7 +16,7 @@ const Docs = () => {
       <Heading mb={7} fontSize="3xl">
         👋 Welcome
       </Heading>
-      <SimpleGrid minChildWidth="240px" columns={4} spacing={6}>
+      <SimpleGrid minChildWidth="240px" spacing={6}>
         {Components.map(({ title, slug, external }: ComponentInterface) => {
           return (
             <CustomLink href={`${slug}`} key={slug}>

--- a/app/src/pages/docs/index.tsx
+++ b/app/src/pages/docs/index.tsx
@@ -16,7 +16,7 @@ const Docs = () => {
       <Heading mb={7} fontSize="3xl">
         👋 Welcome
       </Heading>
-      <SimpleGrid columns={4} spacing={6}>
+      <SimpleGrid minChildWidth="240px" columns={4} spacing={6}>
         {Components.map(({ title, slug, external }: ComponentInterface) => {
           return (
             <CustomLink href={`${slug}`} key={slug}>


### PR DESCRIPTION
**Context**
Docs page did not make the responsive correctly.


**Solution**
Add _minChildWith_ prop used on Chakra SimpleGrid component to **make the grid responsive and adjust automatically without passing columns**

More info: https://chakra-ui.com/docs/components/simple-grid/usage#auto-responsive-grid

**Demo**

![Screen Recording 2022-08-28 at 00 10 51](https://user-images.githubusercontent.com/74491547/187049962-e140fe01-6e18-4af2-a116-59967460e943.gif)

